### PR TITLE
add commented out log box ignore to App.js

### DIFF
--- a/frontend/BarkMingle/App.js
+++ b/frontend/BarkMingle/App.js
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, LogBox } from 'react-native';
 import StackNavigator from './StackNavigator';
 import { NavigationContainer } from '@react-navigation/native';
 import { AuthProvider } from './hooks/useAuth';
@@ -9,6 +9,8 @@ import { useFonts, Baloo2_400Regular, Baloo2_500Medium, Baloo2_600SemiBold, Balo
 import Axios from "axios";
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+//Ignore all log notifications
+// LogBox.ignoreAllLogs();
 
 export default function App() {
   // Sample connection


### PR DESCRIPTION
Added a commented out LogBox.ignoreAllLogs(); to line 13 of App.js and imported LogBox from 'react-native'. This should turn off error notifications (https://reactnative.dev/blog/2020/07/06/version-0.63), but I have it commented out for now as we are still working and might need the warnings.